### PR TITLE
Fix data locations, add support for other continents

### DIFF
--- a/pyhigh/elevation.py
+++ b/pyhigh/elevation.py
@@ -9,31 +9,44 @@ from .hgt import read_elevation_from_file
 
 CACHE_DIR = Path(__file__).resolve().parent / '.cache'
 
-def get_hgt_name(lat, lon, hgt_dot=True):
-    retval = ''
+CONTINENTS=["Eurasia","North_America","Africa","Australia","Islands","South_America"]
 
-    retval += 'N{:02d}'.format(+int(floor(lat)))
-    retval += 'W{:03d}'.format(-int(floor(lon)))
-    if hgt_dot:
-        retval += '.'
-    retval += 'hgt'
+def get_hgt_name(lat, lon,continent):
+    if continent in CONTINENTS:
+        retval = continent + '/'
+    else:
+        raise ValueError(f'Continent "{continent}" not in list of continents:', CONTINENTS)
+    #lat
+    if lat < 0:
+        prefix = 'S'
+    else:
+        prefix = 'N'
+    retval += prefix+'{:02d}'.format(abs(int(floor(lat))))
+    
+    #long
+    if lon < 0:
+        prefix = 'W'
+    else:
+        prefix = 'E'
+    retval += prefix+'{:03d}'.format(abs(int(floor(lon))))
+    retval += '.hgt'
 
     return retval
 
-def get_zip_name(lat, lon):
-    return get_hgt_name(lat, lon, lat<=54) + '.zip'
+def get_zip_name(lat, lon, continent):
+    return get_hgt_name(lat, lon, continent) + '.zip'
 
 def get_url_for_zip(zip_name):
-    return f'https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/North_America/{zip_name}'
+    return f'https://firmware.ardupilot.org/SRTM/{zip_name}'
 
 def clear_cache():
     rmtree(CACHE_DIR)
 
-def get_elevation_batch(lat_lon_list):
+def get_elevation_batch(lat_lon_cont_list):
     # organize requests by filename
     req_dict = {}
-    for k, (lat, lon) in enumerate(lat_lon_list):
-        key = int(floor(lat)), int(floor(lon))
+    for k, (lat, lon, continent) in enumerate(lat_lon_cont_list):
+        key = int(floor(lat)), int(floor(lon)), continent
         if key not in req_dict:
             req_dict[key] = ([], [], [])
         req_dict[key][0].append(k)
@@ -41,19 +54,22 @@ def get_elevation_batch(lat_lon_list):
         req_dict[key][2].append(lon)
 
     # process the files one-by-one
-    retval = np.zeros(len(lat_lon_list))
-    for (lat_int, lon_int), (indices, lats, lons) in req_dict.items():
+    retval = np.zeros(len(lat_lon_cont_list))
+    for (lat_int, lon_int, continent), (indices, lats, lons) in req_dict.items():
         # find the location of the file
-        filename = get_hgt_name(lat_int, lon_int)
+        
+        filename = get_hgt_name(lat_int, lon_int, continent)
         fullfile = CACHE_DIR / filename
+
         # download the file if needed
         if not fullfile.is_file():
             # if not determine the URL where it is located
-            zip_name = get_zip_name(lat_int, lon_int)
+            zip_name = get_zip_name(lat_int, lon_int, continent)
             url = get_url_for_zip(zip_name)
             # then download the file
             print(f'Downloading {zip_name}')
             CACHE_DIR.mkdir(exist_ok=True, parents=True)
+            (CACHE_DIR / continent).mkdir(exist_ok=True, parents=True)
             download(url, CACHE_DIR / zip_name)
             # finally unzip and remove the file
             unzip(CACHE_DIR / zip_name)
@@ -65,8 +81,8 @@ def get_elevation_batch(lat_lon_list):
     # return the elevation data
     return retval
 
-def get_elevation(lat, lon):
-    return get_elevation_batch([(lat, lon)])[0]
+def get_elevation(lat, lon, continent):
+    return get_elevation_batch([(lat, lon, continent)])[0]
 
 if __name__ == '__main__':
-    print(get_elevation(36.52011, -118.671))  # should be 1884
+    print(get_elevation(36.52011, -118.671, "North_America"))  # should be 1884

--- a/pyhigh/pyhigh.py
+++ b/pyhigh/pyhigh.py
@@ -7,11 +7,12 @@ def main():
     parser = ArgumentParser()
     parser.add_argument('--lat', type=float, default=None)
     parser.add_argument('--lon', type=float, default=None)
+    parser.add_argument('--continent', type=str, default="North_America")
     parser.add_argument('--clean', action='store_true')
 
     # parse command line input
     args = parser.parse_args()
-
+ 
     # clear the cache if desired
     if args.clean:
         clear_cache()
@@ -20,7 +21,7 @@ def main():
     lat, lon = args.lat, args.lon
     if lat is not None:
         if lon is not None:
-            print(get_elevation(lat=lat, lon=lon))
+            print(get_elevation(lat=lat, lon=lon, continent=args.continent))
         else:
             raise Exception('Must specify longitude with --lon')
     else:

--- a/tests/test_pyhigh.py
+++ b/tests/test_pyhigh.py
@@ -2,9 +2,12 @@ import numpy as np
 from pyhigh import *
 
 def test_pyhigh():
-    assert get_elevation(36.52011, -118.671) == 1884
+    assert get_elevation(36.52011, -118.671, "North_America") == 1884
 
-    res = get_elevation_batch([(36.52011, -118.671), (36.62011, -118.771)])
+    res = get_elevation_batch([(36.52011, -118.671,"North_America"), (36.62011, -118.771,"North_America")])
     assert np.array_equal(res, [1884, 2438])
 
     clear_cache()
+
+if __name__ == "__main__":
+    test_pyhigh()


### PR DESCRIPTION
Features:

- Includes support for other continents, passed on command line via the `--continent` argument or as a third option to `elevation.get_elevation()`. The list of continent names is `elevation.CONTINENTS`. Defaults to `"North_America"`.

Fixes:

- Previous link to data 404's. The data is hosted in other locations (such as those identified in #1) and one of these has been added instead. Perhaps the data should be placed in a Zenodo repository so a protected copy is available in case this happens in future.